### PR TITLE
Accounted for error 25, header edit

### DIFF
--- a/6.simple_simple_shell.c
+++ b/6.simple_simple_shell.c
@@ -15,12 +15,14 @@ int main(void)
 	{
 		if (isatty(fileno(stdin)))
 		       	write(2, "$ ", 2); /* prompt user for input */
-		
 		if (getline(&lineptr, &n, stdin) == -1)
 		{
-			if (errno = 0)
+			if (errno == 0)
 				break; /* this means EOF */
-			else
+			else if (errno == 25)
+			{
+				break;
+			}
 			{
 				perror("getline"); /* getline error */
 				break;
@@ -84,8 +86,8 @@ int fork_find_exec(char *lineptr, char **exec_str)
         int status = 0;
         char *path_str = NULL;
         char word_path[5] = {'P', 'A', 'T', 'H', '\0'};
+
         child = fork();
-        
 	if (child == -1) /* fork fail */
 	{
 		free(lineptr);

--- a/shell.h
+++ b/shell.h
@@ -8,6 +8,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <errno.h>
 
 extern char **environ;
 
@@ -44,6 +45,7 @@ char *_strncpy(char *dest, char *src, int n);
 int _strspn(char *s, char *accept);
 
 /* Fork the stream for execve */
-int fork_find_exec(char *lineptr, char **exec_str)
+int fork_find_exec(char *lineptr, char **exec_str);
+
 /* SHELL_H end */
 #endif


### PR DESCRIPTION
Error 25 is added seemingly by default somewhere in our code between our initial definition of errno at 0. If we hard code to ignore it, functionality remains the same and does not have extraneous output to stderr